### PR TITLE
feat: 新增留言板功能（Bulletin Board）

### DIFF
--- a/backend/src/main/java/com/example/backend/controller/BulletinBoardController.java
+++ b/backend/src/main/java/com/example/backend/controller/BulletinBoardController.java
@@ -1,0 +1,28 @@
+package com.example.backend.controller;
+
+import com.example.backend.model.BulletinBoardMessage;
+import com.example.backend.service.BulletinBoardService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/bulletinboard")
+public class BulletinBoardController {
+    @Autowired
+    private BulletinBoardService bulletinBoardService;
+
+    @GetMapping
+    public ResponseEntity<List<BulletinBoardMessage>> getAllMessages() {
+        List<BulletinBoardMessage> messages = bulletinBoardService.getAllMessages();
+        return ResponseEntity.ok(messages);
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> createMessage(@RequestBody BulletinBoardMessage message) {
+        bulletinBoardService.createMessage(message);
+        return ResponseEntity.ok().build();
+    }
+} 

--- a/backend/src/main/java/com/example/backend/dao/BulletinBoardDao.java
+++ b/backend/src/main/java/com/example/backend/dao/BulletinBoardDao.java
@@ -1,0 +1,9 @@
+package com.example.backend.dao;
+
+import com.example.backend.model.BulletinBoardMessage;
+import java.util.List;
+
+public interface BulletinBoardDao {
+    List<BulletinBoardMessage> getAllMessages();
+    void createMessage(BulletinBoardMessage message);
+} 

--- a/backend/src/main/java/com/example/backend/dao/WorkerDao.java
+++ b/backend/src/main/java/com/example/backend/dao/WorkerDao.java
@@ -6,4 +6,5 @@ import java.util.List;
 public interface WorkerDao {
     Worker createWorker(Worker worker);
     List<Worker> getAllWorkers();
+    void updateLastModifiedDateByName(String workerName, java.util.Date date);
 } 

--- a/backend/src/main/java/com/example/backend/dao/impl/BulletinBoardDaoImpl.java
+++ b/backend/src/main/java/com/example/backend/dao/impl/BulletinBoardDaoImpl.java
@@ -1,0 +1,37 @@
+package com.example.backend.dao.impl;
+
+import com.example.backend.dao.BulletinBoardDao;
+import com.example.backend.model.BulletinBoardMessage;
+import com.example.backend.rowmapper.BulletinBoardRowMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class BulletinBoardDaoImpl implements BulletinBoardDao {
+    @Autowired
+    private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    @Override
+    public List<BulletinBoardMessage> getAllMessages() {
+        String sql = "SELECT id, name, subject, content, created_at FROM bulletinboard ORDER BY created_at DESC";
+        return namedParameterJdbcTemplate.query(sql, new HashMap<>(), new BulletinBoardRowMapper());
+    }
+
+    @Override
+    public void createMessage(BulletinBoardMessage message) {
+        String sql = "INSERT INTO bulletinboard (name, subject, content, created_at) VALUES (:name, :subject, :content, NOW())";
+        Map<String, Object> map = new HashMap<>();
+        map.put("name", message.getName());
+        map.put("subject", message.getSubject());
+        map.put("content", message.getContent());
+        namedParameterJdbcTemplate.update(sql, new MapSqlParameterSource(map), new GeneratedKeyHolder());
+    }
+} 

--- a/backend/src/main/java/com/example/backend/dao/impl/WorkerDaoImpl.java
+++ b/backend/src/main/java/com/example/backend/dao/impl/WorkerDaoImpl.java
@@ -50,4 +50,13 @@ public class WorkerDaoImpl implements WorkerDao {
 
         return workers;
     }
+
+    @Override
+    public void updateLastModifiedDateByName(String workerName, java.util.Date date) {
+        String sql = "UPDATE workers SET last_modified_date = :date WHERE name = :name";
+        Map<String, Object> map = new HashMap<>();
+        map.put("date", date);
+        map.put("name", workerName);
+        namedParameterJdbcTemplate.update(sql, map);
+    }
 } 

--- a/backend/src/main/java/com/example/backend/model/BulletinBoardMessage.java
+++ b/backend/src/main/java/com/example/backend/model/BulletinBoardMessage.java
@@ -1,0 +1,26 @@
+package com.example.backend.model;
+
+import java.util.Date;
+
+public class BulletinBoardMessage {
+    private Integer id;
+    private String name;
+    private String subject;
+    private String content;
+    private Date createdAt;
+
+    public Integer getId() { return id; }
+    public void setId(Integer id) { this.id = id; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getSubject() { return subject; }
+    public void setSubject(String subject) { this.subject = subject; }
+
+    public String getContent() { return content; }
+    public void setContent(String content) { this.content = content; }
+
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+} 

--- a/backend/src/main/java/com/example/backend/rowmapper/BulletinBoardRowMapper.java
+++ b/backend/src/main/java/com/example/backend/rowmapper/BulletinBoardRowMapper.java
@@ -1,0 +1,20 @@
+package com.example.backend.rowmapper;
+
+import com.example.backend.model.BulletinBoardMessage;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class BulletinBoardRowMapper implements RowMapper<BulletinBoardMessage> {
+    @Override
+    public BulletinBoardMessage mapRow(ResultSet rs, int rowNum) throws SQLException {
+        BulletinBoardMessage msg = new BulletinBoardMessage();
+        msg.setId(rs.getInt("id"));
+        msg.setName(rs.getString("name"));
+        msg.setSubject(rs.getString("subject"));
+        msg.setContent(rs.getString("content"));
+        msg.setCreatedAt(rs.getTimestamp("created_at"));
+        return msg;
+    }
+} 

--- a/backend/src/main/java/com/example/backend/service/BulletinBoardService.java
+++ b/backend/src/main/java/com/example/backend/service/BulletinBoardService.java
@@ -1,0 +1,9 @@
+package com.example.backend.service;
+
+import com.example.backend.model.BulletinBoardMessage;
+import java.util.List;
+
+public interface BulletinBoardService {
+    List<BulletinBoardMessage> getAllMessages();
+    void createMessage(BulletinBoardMessage message);
+} 

--- a/backend/src/main/java/com/example/backend/service/impl/BulletinBoardServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/service/impl/BulletinBoardServiceImpl.java
@@ -1,0 +1,25 @@
+package com.example.backend.service.impl;
+
+import com.example.backend.dao.BulletinBoardDao;
+import com.example.backend.model.BulletinBoardMessage;
+import com.example.backend.service.BulletinBoardService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class BulletinBoardServiceImpl implements BulletinBoardService {
+    @Autowired
+    private BulletinBoardDao bulletinBoardDao;
+
+    @Override
+    public List<BulletinBoardMessage> getAllMessages() {
+        return bulletinBoardDao.getAllMessages();
+    }
+
+    @Override
+    public void createMessage(BulletinBoardMessage message) {
+        bulletinBoardDao.createMessage(message);
+    }
+} 

--- a/backend/src/main/java/com/example/backend/service/impl/WorkerServiceImpl.java
+++ b/backend/src/main/java/com/example/backend/service/impl/WorkerServiceImpl.java
@@ -72,6 +72,9 @@ public class WorkerServiceImpl implements WorkerService {
 
         Path path = folderPath.resolve(fileName);
         Files.copy(file.getInputStream(), path, StandardCopyOption.REPLACE_EXISTING);
+
+        workerDao.updateLastModifiedDateByName(workerName, new Date());
+
         return fileName;
     }
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import HomePage from './pages/HomePage';
 import FilePage from './pages/FilePage';
+import MessageBoard from './pages/MessageBoard';
 import Sidebar from './components/Sidebar';
 
 function App() {
@@ -13,6 +14,7 @@ function App() {
           <Routes>
             <Route path="/" element={<HomePage />} />
             <Route path="/file/:workerName" element={<FilePage />} />
+            <Route path="/message-board" element={<MessageBoard />} />
           </Routes>
         </div>
       </div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,14 +2,20 @@ import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import HomePage from './pages/HomePage';
 import FilePage from './pages/FilePage';
+import Sidebar from './components/Sidebar';
 
 function App() {
   return (
     <Router>
-      <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/file/:workerName" element={<FilePage />} />
-      </Routes>
+      <div style={{ display: 'flex' }}>
+        <Sidebar />
+        <div style={{ flex: 1 }}>
+          <Routes>
+            <Route path="/" element={<HomePage />} />
+            <Route path="/file/:workerName" element={<FilePage />} />
+          </Routes>
+        </div>
+      </div>
     </Router>
   );
 }

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -6,7 +6,7 @@ const Sidebar = () => (
     width: '180px',
     minHeight: '100vh',
     background: '#f0f0f0',
-    padding: '30px 0',
+    padding: '80px 0',
     boxSizing: 'border-box'
   }}>
     <nav style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+const Sidebar = () => (
+  <div style={{
+    width: '180px',
+    minHeight: '100vh',
+    background: '#f0f0f0',
+    padding: '30px 0',
+    boxSizing: 'border-box'
+  }}>
+    <nav style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+      <NavLink
+        to="/"
+        style={({ isActive }) => ({
+          color: isActive ? '#1976d2' : '#333',
+          fontWeight: isActive ? 'bold' : 'normal',
+          textDecoration: 'none',
+          fontSize: '18px',
+          padding: '8px 24px',
+        })}
+        end
+      >
+        工人列表
+      </NavLink>
+      <NavLink
+        to="/message-board"
+        style={({ isActive }) => ({
+          color: isActive ? '#1976d2' : '#333',
+          fontWeight: isActive ? 'bold' : 'normal',
+          textDecoration: 'none',
+          fontSize: '18px',
+          padding: '8px 24px',
+        })}
+      >
+        留言板
+      </NavLink>
+    </nav>
+  </div>
+);
+
+export default Sidebar; 

--- a/frontend/src/pages/FilePage.jsx
+++ b/frontend/src/pages/FilePage.jsx
@@ -37,7 +37,8 @@ const FilePage = () => {
 
   return (
     <div style={commonStyles.container}>
-      <div style={{ ...commonStyles.card, display: 'flex', maxWidth: '1000px', width: '100%' }}>
+      {/* 移除 card 樣式，直接顯示內容 */}
+      <div style={{ display: 'flex', maxWidth: '1000px', width: '100%' }}>
         {/* 左邊區塊：上傳/下載 */}
         <div style={{ flex: 1, marginRight: '40px' }}>
           <h2>{workerName} 的檔案管理</h2>

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -3,6 +3,13 @@ import { useNavigate } from 'react-router-dom';
 import { useWorkers } from '../hooks/useWorkers';
 import { commonStyles } from '../styles/common';
 
+// 日期格式化工具
+const formatDate = (dateStr) => {
+  if (!dateStr) return '';
+  const date = new Date(dateStr);
+  return date.toLocaleString('zh-TW', { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' });
+};
+
 const HomePage = () => {
   const navigate = useNavigate();
   const { workers, loading, error, fetchWorkers, addWorker } = useWorkers();
@@ -57,8 +64,10 @@ const HomePage = () => {
         <table style={commonStyles.table}>
           <thead>
             <tr>
-              <th style={commonStyles.tableCell}>ID</th>
-              <th style={commonStyles.tableCell}>Name</th>
+              <th style={commonStyles.tableCell}>工號</th>
+              <th style={commonStyles.tableCell}>名字</th>
+              <th style={commonStyles.tableCell}>建立日期</th>
+              <th style={commonStyles.tableCell}>最後修改日期</th>
               <th style={commonStyles.tableCell}>檔案</th>
             </tr>
           </thead>
@@ -67,6 +76,8 @@ const HomePage = () => {
               <tr key={worker.id}>
                 <td style={commonStyles.tableCell}>{worker.id}</td>
                 <td style={commonStyles.tableCell}>{worker.name}</td>
+                <td style={commonStyles.tableCell}>{formatDate(worker.createdDate)}</td>
+                <td style={commonStyles.tableCell}>{formatDate(worker.lastModifiedDate)}</td>
                 <td style={commonStyles.tableCell}>
                   <button 
                     onClick={() => handleFileButtonClick(worker.name)}

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -31,7 +31,7 @@ const HomePage = () => {
 
   return (
     <div style={commonStyles.container}>
-      <div style={commonStyles.card}>
+      <div>
         <h2>➕ 新增工人</h2>
 
         <div style={{ marginBottom: '10px' }}>

--- a/frontend/src/pages/MessageBoard.jsx
+++ b/frontend/src/pages/MessageBoard.jsx
@@ -7,13 +7,12 @@ export const getMessages = () => axios.get(API_BASE_URL);
 export const postMessage = (data) => axios.post(API_BASE_URL, data);
 
 const MessageBoard = () => {
-  const [messages, setMessages] = useState([
-    { id: 1, name: '小明', subject: '測試主題', content: '這是留言內容', createdAt: '2025/6/23 下午4:18:56' }
-  ]);
+  const [messages, setMessages] = useState([]);
   const [form, setForm] = useState({ name: '', subject: '', content: '' });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
+  const [selectedMessage, setSelectedMessage] = useState(null);
 
   // 取得留言列表
   const fetchMessages = async () => {
@@ -30,7 +29,7 @@ const MessageBoard = () => {
   };
 
   useEffect(() => {
-    // fetchMessages();
+    fetchMessages();
   }, []);
 
   // 處理表單輸入
@@ -78,13 +77,69 @@ const MessageBoard = () => {
             {messages.map((msg) => (
               <tr key={msg.id}>
                 <td style={{ padding: '8px 16px', border: '1px solid #ddd' }}>{msg.name}</td>
-                <td style={{ padding: '8px 16px', border: '1px solid #ddd' }}>{msg.subject}</td>
-                <td style={{ padding: '8px 16px', border: '1px solid #ddd' }}>{msg.createdAt}</td>
+                <td
+                  style={{
+                    padding: '8px 16px',
+                    border: '1px solid #ddd',
+                    color: '#1976d2',
+                    cursor: 'pointer',
+                    textDecoration: 'underline'
+                  }}
+                  onClick={() => setSelectedMessage(msg)}
+                >
+                  {msg.subject}
+                </td>
+                <td style={{ padding: '8px 16px', border: '1px solid #ddd' }}>
+                  {msg.createdAt ? new Date(msg.createdAt).toLocaleString('zh-TW') : ''}
+                </td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
+
+      {/* Modal for message content */}
+      {selectedMessage && (
+        <div style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          width: '100vw',
+          height: '100vh',
+          background: 'rgba(0,0,0,0.3)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          zIndex: 1000
+        }}>
+          <div style={{
+            background: 'white',
+            padding: 32,
+            borderRadius: 8,
+            minWidth: 320,
+            maxWidth: 480,
+            boxShadow: '0 2px 16px rgba(0,0,0,0.2)'
+          }}>
+            <h3 style={{ marginTop: 0, marginBottom: 16 }}>留言內容</h3>
+            <div style={{ marginBottom: 24, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+              {selectedMessage.content}
+            </div>
+            <button
+              onClick={() => setSelectedMessage(null)}
+              style={{
+                padding: '8px 24px',
+                background: '#1976d2',
+                color: 'white',
+                border: 'none',
+                borderRadius: 4,
+                cursor: 'pointer'
+              }}
+            >
+              完成
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* 留言表單 */}
       <form onSubmit={handleSubmit}>

--- a/frontend/src/pages/MessageBoard.jsx
+++ b/frontend/src/pages/MessageBoard.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const MessageBoard = () => (
+  <div style={{ padding: '40px' }}>
+    <h2>留言板</h2>
+    <p>（此區暫時空白）</p>
+  </div>
+);
+
+export default MessageBoard; 

--- a/frontend/src/pages/MessageBoard.jsx
+++ b/frontend/src/pages/MessageBoard.jsx
@@ -1,10 +1,162 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
 
-const MessageBoard = () => (
-  <div style={{ padding: '40px' }}>
-    <h2>留言板</h2>
-    <p>（此區暫時空白）</p>
-  </div>
-);
+const API_BASE_URL = 'http://localhost:8080/api/bulletinboard';
+
+export const getMessages = () => axios.get(API_BASE_URL);
+export const postMessage = (data) => axios.post(API_BASE_URL, data);
+
+const MessageBoard = () => {
+  const [messages, setMessages] = useState([
+    { id: 1, name: '小明', subject: '測試主題', content: '這是留言內容', createdAt: '2025/6/23 下午4:18:56' }
+  ]);
+  const [form, setForm] = useState({ name: '', subject: '', content: '' });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  // 取得留言列表
+  const fetchMessages = async () => {
+    try {
+      setLoading(true);
+      setError('');
+      const res = await getMessages();
+      setMessages(Array.isArray(res.data) ? res.data : []);
+    } catch (err) {
+      setError('載入留言失敗');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    // fetchMessages();
+  }, []);
+
+  // 處理表單輸入
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  // 送出留言
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!form.name.trim() || !form.subject.trim() || !form.content.trim()) {
+      setError('請填寫所有欄位');
+      return;
+    }
+    try {
+      setLoading(true);
+      setError('');
+      await postMessage(form);
+      setForm({ name: '', subject: '', content: '' });
+      setSuccess('留言成功！');
+      fetchMessages();
+    } catch (err) {
+      setError('留言失敗');
+    } finally {
+      setLoading(false);
+      setTimeout(() => setSuccess(''), 2000);
+    }
+  };
+
+  return (
+    <div style={{ padding: '20px', maxWidth: '100%' }}>
+      <h2>留言板</h2>
+      
+      {/* 留言列表 */}
+      <div style={{ marginBottom: '30px' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse', backgroundColor: 'white' }}>
+          <thead>
+            <tr>
+              <th style={{ padding: '8px 16px', textAlign: 'left', border: '1px solid #ddd', width: '15%' }}>姓名</th>
+              <th style={{ padding: '8px 16px', textAlign: 'left', border: '1px solid #ddd', width: '60%' }}>主題</th>
+              <th style={{ padding: '8px 16px', textAlign: 'left', border: '1px solid #ddd', width: '25%' }}>留言時間</th>
+            </tr>
+          </thead>
+          <tbody>
+            {messages.map((msg) => (
+              <tr key={msg.id}>
+                <td style={{ padding: '8px 16px', border: '1px solid #ddd' }}>{msg.name}</td>
+                <td style={{ padding: '8px 16px', border: '1px solid #ddd' }}>{msg.subject}</td>
+                <td style={{ padding: '8px 16px', border: '1px solid #ddd' }}>{msg.createdAt}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* 留言表單 */}
+      <form onSubmit={handleSubmit}>
+        <div style={{ marginBottom: '20px' }}>
+          <div style={{ marginBottom: '15px' }}>
+            <label style={{ display: 'block', marginBottom: '5px' }}>姓名</label>
+            <input
+              name="name"
+              value={form.name}
+              onChange={handleChange}
+              style={{
+                width: '200px',
+                padding: '8px',
+                border: '1px solid #ddd',
+                borderRadius: '4px'
+              }}
+              placeholder="請輸入姓名"
+            />
+          </div>
+          <div style={{ marginBottom: '15px' }}>
+            <label style={{ display: 'block', marginBottom: '5px' }}>主題</label>
+            <input
+              name="subject"
+              value={form.subject}
+              onChange={handleChange}
+              style={{
+                width: '100%',
+                padding: '8px',
+                border: '1px solid #ddd',
+                borderRadius: '4px'
+              }}
+              placeholder="請輸入主題"
+            />
+          </div>
+          <div style={{ marginBottom: '15px' }}>
+            <label style={{ display: 'block', marginBottom: '5px' }}>留言內容</label>
+            <textarea
+              name="content"
+              value={form.content}
+              onChange={handleChange}
+              style={{
+                width: '100%',
+                padding: '8px',
+                border: '1px solid #ddd',
+                borderRadius: '4px',
+                minHeight: '100px',
+                resize: 'vertical'
+              }}
+              placeholder="請輸入留言內容"
+            />
+          </div>
+          <button
+            type="submit"
+            style={{
+              padding: '8px 24px',
+              backgroundColor: '#1976d2',
+              color: 'white',
+              border: 'none',
+              borderRadius: '4px',
+              cursor: 'pointer'
+            }}
+            disabled={loading}
+          >
+            送出
+          </button>
+        </div>
+      </form>
+      
+      {error && <div style={{ color: 'red', marginTop: '12px' }}>{error}</div>}
+      {success && <div style={{ color: 'green', marginTop: '12px' }}>{success}</div>}
+    </div>
+  );
+};
 
 export default MessageBoard; 

--- a/frontend/src/services/bulletinBoard.js
+++ b/frontend/src/services/bulletinBoard.js
@@ -1,0 +1,6 @@
+import axios from 'axios';
+
+const API_BASE_URL = 'http://localhost:8080/api/bulletinboard';
+
+export const getMessages = () => axios.get(API_BASE_URL);
+export const postMessage = (data) => axios.post(API_BASE_URL, data); 

--- a/frontend/src/styles/common.js
+++ b/frontend/src/styles/common.js
@@ -1,12 +1,13 @@
 export const commonStyles = {
   container: {
     display: 'flex',
-    justifyContent: 'center',
+    justifyContent: 'flex-start',
     alignItems: 'flex-start',
     minHeight: '100vh',
     backgroundColor: '#f8f8f8',
     fontFamily: 'Arial',
     paddingTop: '40px',
+    paddingLeft: '40px',
   },
   card: {
     padding: '40px',


### PR DESCRIPTION
feat: 新增留言板功能（Bulletin Board）

## 主要變更內容

本 PR 為專案新增留言板（Bulletin Board）功能，包含前後端整合，讓使用者可以在網頁上留言、瀏覽留言。

### Backend（Spring Boot）
- 新增 `BulletinBoardController`，提供留言查詢與新增 API（/api/bulletinboard）。
- 新增 `BulletinBoardService` 及其實作，負責留言業務邏輯。
- 新增 `BulletinBoardDao` 及其實作，負責留言資料存取。
- 新增留言資料表對應的 Model、RowMapper。

### Frontend（React）
- 新增 `MessageBoard` 頁面，支援留言列表、留言內容 Modal、留言表單。
- 新增 `Sidebar`，可切換工人列表與留言板。
- 路由整合，支援 `/message-board`。
- 新增 `services/bulletinBoard.js`，串接留言板 API。

### 其他
- 工人列表頁面（HomePage）欄位優化。

---

此功能讓使用者可即時留言、查看所有留言，提升互動性。請協助 Review，感謝！ 